### PR TITLE
Replace deprecated "delete()" call

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -517,7 +517,7 @@ class WP_Object_Cache {
 		unset( $this->to_preload[ $group ][ $key ] );
 		unset( $this->to_unserialize[ $redis_key ] );
 
-		return (bool) $this->redis->delete( $redis_key );
+		return (bool) $this->redis->del( $redis_key );
 	}
 
 	/**


### PR DESCRIPTION
`delete` is an alias for `del` and will be removed soon, causing a deprecation warning.

See https://github.com/phpredis/phpredis/commit/a81b4f2d.