### PR TITLE
Really Rewrote WP_Object_Cache implementation

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -333,7 +333,8 @@ class WP_Object_Cache {
 			$this->redis = $redis_instance;
 			$this->redis->connect( $redis['host'], $redis['port'] );
 			$this->redis->setOption( Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE );
-			$this->redis->setOption(Redis::OPT_PREFIX, WP_CACHE_KEY_SALT . ':');
+			if( !empty( WP_CACHE_KEY_SALT ) )
+				$this->redis->setOption(Redis::OPT_PREFIX, WP_CACHE_KEY_SALT . ':');
 
 			if ( isset( $redis['auth'] ) ) {
 				$this->redis->auth( $redis['auth'] );

--- a/object-cache.php
+++ b/object-cache.php
@@ -212,7 +212,8 @@ function wp_cache_add_global_groups( $groups ) {
  * @param string|array $groups A group or an array of groups to add.
  */
 function wp_cache_add_non_persistent_groups( $groups ) {
-	// Default cache doesn't persist so nothing to do here.
+	global $wp_object_cache;
+	$wp_object_cache->add_non_persistent_groups( $groups );
 }
 
 class WP_Object_Cache {


### PR DESCRIPTION
Reopening this because I screwed up the last PR.

Unfortunately I had intended to just remove just the preload feature to fix the scaling issue but that feature was masking other issues and this turned into a whole rewrite using the existing work as a reference.

In my testing this version is more reliable and just as fast as with the preloading due to the PHP cache array optimizations. I am using a locally hosted version of redis however and the preloading optimization may be targeted to address network latency.