### PR TITLE
Don't define functions and classes if Redis is unavailable or disabled

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -11,17 +11,11 @@
  * License URI: https://www.gnu.org/licenses/quick-guide-gplv3.html
  */
 
-// Check if Redis class is installed
-if ( ! class_exists( 'Redis' ) ) {
-	return;
-}
-
-// Check if caching should be disabled.
-if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) {
-	return;
-}
-
-if ( true ) : // Prevent functions and classes from being defined.
+/**
+ * Check if Redis class is installed and caching is not disabled.
+ * If false, prevent functions and classes from being defined.
+ */
+if ( class_exists( 'Redis' ) && ( ! defined( 'WP_REDIS_DISABLED' ) || ! WP_REDIS_DISABLED ) :
 
 /**
  * Adds a value to cache.


### PR DESCRIPTION
Amends https://github.com/pressjitsu/pj-object-cache-red/commit/21926c587157365ae8d573191647fefc18c418e3 and https://github.com/pressjitsu/pj-object-cache-red/commit/a10f645a4f2abf2a68aa7085ed6db1e05922e7f0.

The "fix" in https://github.com/pressjitsu/pj-object-cache-red/commit/21926c587157365ae8d573191647fefc18c418e3 did nothing because `true` is always true and thus the functions are still defined as seen in this examples:

**cache-broken.php:**
```php
<?php
return;

function foo1() {};

if ( true ) :
	function foo2() {};
endif;
```
```php
<?php
require_once __DIR__ . '/cache-broken.php';
var_dump( function_exists( 'foo1' ) ); // bool(true)
var_dump( function_exists( 'foo2' ) ); // bool(true)
```

**cache-fixed.php:**
```php
<?php
return;

function foo1() {};

if ( false ) :
	function foo2() {};
endif;
```
```php
<?php
require_once __DIR__ . '/cache-fixed.php';
var_dump( function_exists( 'foo1' ) ); // bool(true)
var_dump( function_exists( 'foo2' ) ); // bool(false)
```